### PR TITLE
fix(reload.go): Negotiate WSS connection when server is running HTTPS

### DIFF
--- a/reload.go
+++ b/reload.go
@@ -137,7 +137,11 @@ func (reload *Reloader) Handle(next http.Handler) http.Handler {
 func (reload *Reloader) ServeWS(w http.ResponseWriter, r *http.Request) {
 	version := r.URL.Query().Get("v")
 	if version != wsCurrentVersion {
-		reload.Log.Printf("Injected script version is out of date (v%s < v%s)\n", version, wsCurrentVersion)
+		reload.Log.Printf(
+			"Injected script version is out of date (v%s < v%s)\n",
+			version,
+			wsCurrentVersion,
+		)
 	}
 
 	conn, err := reload.Upgrader.Upgrade(w, r, nil)
@@ -167,7 +171,8 @@ func InjectedScript(endpoint string) string {
 	  setTimeout(() => listen(true), 1000)
 	}
 	function listen(isRetry) {
-	  let ws = new WebSocket("ws://" + location.host + "%s?v=%s")
+    let protocol = location.protocol === "https:" ? "wss://" : "ws://"
+	  let ws = new WebSocket(protocol + location.host + "%s?v=%s")
 	  if(isRetry) {
 	    ws.onopen = () => window.location.reload()
 	  }


### PR DESCRIPTION
Updated JS injected into HTML templates. Check `location.protocol` if it is HTTPS, use `wss://` in the protocol portion of the conneciton string, else use `ws://`.

> Note: `gofmt`, or `golines` appears to have reformatted whitespace in reload.go

Fixes https://github.com/aarol/reload/issues/1